### PR TITLE
Clarify width control attribute naming

### DIFF
--- a/src/utils/useBlockControls.js
+++ b/src/utils/useBlockControls.js
@@ -245,13 +245,13 @@ export function useBlockControls(
 							xl: desktopImg,
 							xxl: desktopImg,
 						}[ bp ];
+                                                // Build the attribute key for this breakpoint.
+                                                // "" becomes widthBase, "sm" becomes widthSm, and so on.
+                                                const camel = bp
+                                                        ? bp.charAt( 0 ).toUpperCase() + bp.slice( 1 )
+                                                         : 'Base';
+                                                const attr = `width${ camel }`;
 
-						/* --- fix here --------------------------------------------------- */
-						const camel = bp
-							? bp.charAt( 0 ).toUpperCase() + bp.slice( 1 )
-							: 'Base';
-						const attr = `width${ camel }`;
-						/* ---------------------------------------------------------------- */
 
 						return (
 							<WidthControl


### PR DESCRIPTION
## Summary
- update `useBlockControls.js` comment to explain width attribute keys

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6851f03434088323a7a5bc7f7a66cf42