### PR TITLE
Fix missing controls and add align support

### DIFF
--- a/src/carousel/render.php
+++ b/src/carousel/render.php
@@ -92,11 +92,20 @@ if ($attributes['autoHeight']) {
 // Classes for pause/pagination container
 $pause_pagination_classes = array('swiper-pause-pagination');
 if (!$attributes['showPlayPauseButton'] && !$attributes['pagination']) {
-	$pause_pagination_classes[] = 'd-none';
+        $pause_pagination_classes[] = 'd-none';
 }
+
+$wrapper_attributes = get_block_wrapper_attributes(
+        array(
+                'class' => 'swiper',
+                'data-swiper' => wp_json_encode($swiper_data),
+                'aria-roledescription' => 'carousel',
+                'aria-label' => 'Highlighted content',
+        )
+);
 ?>
 
-<div class="swiper wp-block-fancysquares-carousel" data-swiper="<?php echo esc_js(wp_json_encode($swiper_data)); ?>" aria-roledescription="carousel" aria-label="Highlighted content">
+<div <?php echo $wrapper_attributes; ?>>
 	<div class="swiper-wrapper">
 		<?php echo $content; // Slide items
 		?>

--- a/src/content-wrapper/edit.js
+++ b/src/content-wrapper/edit.js
@@ -3,6 +3,7 @@ import {
 	useBlockProps,
 	InspectorControls,
 } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
 import { useBlockControls } from '../utils/useBlockControls';
 import './editor.scss';
 const TEMPLATE = [
@@ -12,6 +13,7 @@ const TEMPLATE = [
 
 export default function Edit( props ) {
 	const { attributes, setAttributes, name, clientId } = props;
+	const { elementTag } = attributes;
 
 	// token field for class options, defaults are in blockConfig.js
 	const { inspectorPanels, previewClasses } = useBlockControls(
@@ -39,7 +41,22 @@ export default function Edit( props ) {
 
 	return (
 		<>
-			<InspectorControls>{ inspectorPanels }</InspectorControls>
+			<InspectorControls>
+				{ inspectorPanels }
+				<PanelBody title="Wrapper Settings" initialOpen={ false }>
+					<SelectControl
+						label="HTML Element"
+						value={ elementTag }
+						options={ [
+							{ label: 'div', value: 'div' },
+							{ label: 'section', value: 'section' },
+						] }
+						onChange={ ( val ) =>
+							setAttributes( { elementTag: val } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
 
 			<div
 				{ ...useBlockProps( {

--- a/src/content-wrapper/style.scss
+++ b/src/content-wrapper/style.scss
@@ -5,8 +5,13 @@
  * Replace them with your own styles or remove the file completely.
  */
 
-.wp-block-fancysquares-container-block {
+.wp-block-fs-blocks-content-wrapper {
 	// background-color: #21759b;
 	// color: #fff;
 	// // padding: 2px;
+	&.alignfull {
+		.wp-block-cover__inner-container {
+			margin: 0 auto !important
+		}
+	}
 }

--- a/src/picture-block/render.php
+++ b/src/picture-block/render.php
@@ -75,6 +75,7 @@ if ($aspect && 'none' !== $aspect) {
 	$figureClasses[] = 'fs-block-image--no-aspect-ratio';
 }
 $figure_class = implode(' ', array_map('esc_attr', $figureClasses));
+$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $figure_class ) );
 
 /**
  * Build <img> classes & inline style if we have a border class
@@ -106,7 +107,7 @@ if ($imgStyle) {
  * Single <img> case: no small/medium/large images
  */
 if (! $hasSmall && ! $hasMedium && ! $hasLarge) : ?>
-	<figure class="<?php echo $figure_class; ?>">
+        <figure <?php echo $wrapper_attributes; ?>>
 		<img
 			decoding="async"
 			loading="lazy"
@@ -115,13 +116,13 @@ if (! $hasSmall && ! $hasMedium && ! $hasLarge) : ?>
 		<?php if (! empty($caption)) : ?>
 			<figcaption><?php echo wp_kses_post($caption); ?></figcaption>
 		<?php endif; ?>
-	</figure>
+        </figure>
 <?php
-	return;
+        return;
 endif;
 ?>
 
-<figure class="<?php echo $figure_class; ?>">
+<figure <?php echo $wrapper_attributes; ?>>
 	<picture>
 		<?php // Up to 600px
 		if ($hasSmall) : ?>


### PR DESCRIPTION
## Summary
- add element tag control to content wrapper block
- support block alignment in carousel and picture blocks

## Testing
- `npm run format`
- `npm run lint:js` *(fails: 36 problems across utils)*

------
https://chatgpt.com/codex/tasks/task_e_6860888a42748323bbc6763fce773c52