### PR TITLE
Add section option for carousel wrapper

### DIFF
--- a/src/carousel/block.json
+++ b/src/carousel/block.json
@@ -71,6 +71,10 @@
 		"autoHeight": {
 			"type": "boolean",
 			"default": false
+		},
+		"elementTag": {
+			"type": "string",
+			"default": "div"
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/src/carousel/edit.js
+++ b/src/carousel/edit.js
@@ -8,6 +8,8 @@ import {
 	PanelBody,
 	RangeControl,
 	ToggleControl,
+	SelectControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
 	Button,
 } from '@wordpress/components';
@@ -47,6 +49,9 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		enableFade,
 		fractionalSlidesEnabled,
 		fractionalSlidesValue,
+
+		// HTML element tag
+		elementTag,
 
 		// ADA specific feature
 		// New attribute for play/pause button
@@ -103,6 +108,17 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						min={ 0 }
 						max={ 100 }
 						step={ 10 }
+					/>
+					<SelectControl
+						label="HTML Element"
+						value={ elementTag }
+						options={ [
+							{ label: 'div', value: 'div' },
+							{ label: 'section', value: 'section' },
+						] }
+						onChange={ ( val ) =>
+							setAttributes( { elementTag: val } )
+						}
 					/>
 					<ToggleControl
 						label="Dots navigation"

--- a/src/carousel/render.php
+++ b/src/carousel/render.php
@@ -20,13 +20,19 @@ $defaults = array(
 	'enableFade'              => false,
 	'fractionalSlidesEnabled' => false,
 	'fractionalSlidesValue'   => 0.25,
-	'showPlayPauseButton'     => false,
-	'breakpoints'             => array(),
-	'autoHeight'              => false,
+        'showPlayPauseButton'     => false,
+        'breakpoints'             => array(),
+        'autoHeight'              => false,
+        'elementTag'              => 'div',
 );
 
 // Merge with defaults
 $attributes = wp_parse_args($attributes, $defaults);
+
+$element_tag = isset($attributes['elementTag']) ? $attributes['elementTag'] : 'div';
+if ($element_tag !== 'section') {
+        $element_tag = 'div';
+}
 
 // Build Swiper configuration
 $swiper_data = array(
@@ -85,8 +91,7 @@ if ($attributes['navigation']) {
 
 // Handle autoHeight
 if ($attributes['autoHeight']) {
-	print_r($attributes['autoHeight']);
-	$swiper_data['autoHeight'] = true;
+        $swiper_data['autoHeight'] = true;
 }
 
 // Classes for pause/pagination container
@@ -95,9 +100,14 @@ if (!$attributes['showPlayPauseButton'] && !$attributes['pagination']) {
         $pause_pagination_classes[] = 'd-none';
 }
 
+$wrapper_classes = array('swiper');
+if ('section' === $element_tag) {
+        $wrapper_classes[] = 'swiper--section';
+}
+
 $wrapper_attributes = get_block_wrapper_attributes(
         array(
-                'class' => 'swiper',
+                'class' => implode(' ', $wrapper_classes),
                 'data-swiper' => wp_json_encode($swiper_data),
                 'aria-roledescription' => 'carousel',
                 'aria-label' => 'Highlighted content',
@@ -105,11 +115,11 @@ $wrapper_attributes = get_block_wrapper_attributes(
 );
 ?>
 
-<div <?php echo $wrapper_attributes; ?>>
-	<div class="swiper-wrapper">
-		<?php echo $content; // Slide items
-		?>
-	</div>
+<<?php echo esc_attr($element_tag); ?> <?php echo $wrapper_attributes; ?>>
+        <div class="swiper-wrapper">
+                <?php echo $content; // Slide items
+                ?>
+        </div>
 
 	<div class="<?php echo esc_attr(implode(' ', $pause_pagination_classes)); ?>">
 		<div class="swiper-pause-pagination__inner-container">
@@ -133,4 +143,4 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		</div>
 	</div>
 
-</div>
+</<?php echo esc_attr($element_tag); ?>>


### PR DESCRIPTION
## Summary
- allow setting carousel wrapper `div` or `section`
- add inspector control for choosing the wrapper tag
- output `swiper--section` class when using a `<section>` tag

## Testing
- `npm run lint:js` *(fails: 42 errors, 2 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68608f7b3ffc8323b98cd37f07d3ee98