### PR TITLE
Add enforce height option to Swiper carousel

### DIFF
--- a/src/carousel/block.json
+++ b/src/carousel/block.json
@@ -72,6 +72,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"enforceHeight": {
+			"type": "boolean",
+			"default": false
+		},
 		"elementTag": {
 			"type": "string",
 			"default": "div"

--- a/src/carousel/edit.js
+++ b/src/carousel/edit.js
@@ -58,6 +58,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		showPlayPauseButton,
 		// auto Height
 		autoHeight,
+		// Enforce equal slide height
+		enforceHeight,
 	} = attributes;
 
 	const [ localBreakpoints, setLocalBreakpoints ] = useState( breakpoints );
@@ -217,6 +219,15 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 						onChange={ () =>
 							setAttributes( {
 								autoHeight: ! autoHeight,
+							} )
+						}
+					/>
+					<ToggleControl
+						label="Enforce Height"
+						checked={ enforceHeight }
+						onChange={ () =>
+							setAttributes( {
+								enforceHeight: ! enforceHeight,
 							} )
 						}
 					/>

--- a/src/carousel/render.php
+++ b/src/carousel/render.php
@@ -22,8 +22,9 @@ $defaults = array(
 	'fractionalSlidesValue'   => 0.25,
         'showPlayPauseButton'     => false,
         'breakpoints'             => array(),
-        'autoHeight'              => false,
-        'elementTag'              => 'div',
+       'autoHeight'              => false,
+       'enforceHeight'           => false,
+       'elementTag'              => 'div',
 );
 
 // Merge with defaults
@@ -107,11 +108,12 @@ if ('section' === $element_tag) {
 
 $wrapper_attributes = get_block_wrapper_attributes(
         array(
-                'class' => implode(' ', $wrapper_classes),
-                'data-swiper' => wp_json_encode($swiper_data),
-                'aria-roledescription' => 'carousel',
-                'aria-label' => 'Highlighted content',
-        )
+               'class' => implode(' ', $wrapper_classes),
+               'data-swiper' => wp_json_encode($swiper_data),
+               'data-enforce-height' => $attributes['enforceHeight'] ? 'true' : 'false',
+               'aria-roledescription' => 'carousel',
+               'aria-label' => 'Highlighted content',
+       )
 );
 ?>
 

--- a/src/carousel/style.scss
+++ b/src/carousel/style.scss
@@ -1,36 +1,43 @@
 .wp-block-fancysquares-slide {
 	&.are-vertically-aligned-center {
-	  margin-top: auto;
-	  margin-bottom: auto;
+		margin-top: auto;
+		margin-bottom: auto;
 	}
 
 	&.are-vertically-aligned-bottom {
-	  margin-top: auto;
-	  margin-bottom: 0;
+		margin-top: auto;
+		margin-bottom: 0;
 	}
-  }
+	&.swiper-slide-enforced-height {
+		display: flex;            /* establishes the stretching context  */
+		flex-direction: column;
+		.wp-block-cover {
+			flex: 1 1 auto;
+		}
+	}
+}
 
-  .wp-block-fancysquares-carousel {
+.wp-block-fancysquares-carousel {
 	.swiper-pagination {
-	  position: static;
-	  margin-top: 14px;
+		position: static;
+		margin-top: 14px;
 
-	  &-bullet {
-		background-color: #090909;
-	  }
+		&-bullet {
+			background-color: #090909;
+		}
 	}
 
 	.wp-block-fancysquares-slide {
-	  box-sizing: border-box;
+		box-sizing: border-box;
 
-	  .wp-block-image.aligncenter {
-		margin-left: auto;
-		margin-right: auto;
-	  }
+		.wp-block-image.aligncenter {
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
 
 	.swiper-button-next,
 	.swiper-button-prev {
-	  color: #090909;
+		color: #090909;
 	}
-  }
+}

--- a/src/carousel/view.js
+++ b/src/carousel/view.js
@@ -1,5 +1,47 @@
+function resizeWidthOnly( start, finish ) {
+	const initialInnerWidth = [ window.innerWidth ];
+	return (
+		( window.onresize = function () {
+			const newInnerWidth = window.innerWidth,
+				previousInnerWidth = initialInnerWidth.length;
+			initialInnerWidth.push( newInnerWidth );
+			if (
+				initialInnerWidth[ previousInnerWidth ] !==
+				initialInnerWidth[ previousInnerWidth - 1 ]
+			) {
+				clearTimeout( finish );
+				finish = setTimeout( start, 350 );
+			}
+		} ),
+		start
+	);
+}
+
 document.addEventListener( 'DOMContentLoaded', () => {
 	const carousels = document.querySelectorAll( '.swiper' );
+	const enforceHeightEls = Array.from( carousels ).filter(
+		( el ) => el.dataset.enforceHeight === 'true'
+	);
+
+	const setAllMinHeights = () => {
+		enforceHeightEls.forEach( ( el ) => {
+			const slides = el.querySelectorAll( '.swiper-slide' );
+			let tallest = 0;
+			slides.forEach( ( slide ) => {
+				slide.style.minHeight = '';
+				if ( slide.offsetHeight > tallest ) {
+					tallest = slide.offsetHeight;
+				}
+			} );
+			slides.forEach( ( slide ) => {
+				slide.style.minHeight = `${ tallest }px`;
+			} );
+		} );
+	};
+
+	if ( enforceHeightEls.length ) {
+		resizeWidthOnly( setAllMinHeights )();
+	}
 
 	carousels.forEach( ( el ) => {
 		// Retrieve config from data-swiper

--- a/src/carousel/view.js
+++ b/src/carousel/view.js
@@ -35,6 +35,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			} );
 			slides.forEach( ( slide ) => {
 				slide.style.minHeight = `${ tallest }px`;
+				// add a class to indicate the height is enforced
+				slide.classList.add( 'swiper-slide-enforced-height' );
 			} );
 		} );
 	};


### PR DESCRIPTION
## Summary
- add `enforceHeight` attribute for carousel block
- expose UI toggle to enable height enforcement
- pass setting to PHP render output
- compute tallest slide and set slide min-height on resize

## Testing
- `npm run format`
- `npx wp-scripts lint-js src/carousel/view.js src/carousel/edit.js`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686337c9881c832387b9ee14722cd734